### PR TITLE
Add dotnet20 to --fixprefix to workaround the "rundll32.exe - This application could not be started." error

### DIFF
--- a/osu-wine
+++ b/osu-wine
@@ -280,7 +280,7 @@ case "$1" in
     rm "$HOME/.local/share/osuconfig/winetricks"
     (wget -O "$HOME/.local/share/osuconfig/winetricks" https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks && chmod +x "$HOME/.local/share/osuconfig/winetricks") || Error "Downloading Winetricks failed, try again later.."
 
-    "$HOME/.local/share/osuconfig/winetricks" -q -f dotnet48 gdiplus_winxp comctl32
+    "$HOME/.local/share/osuconfig/winetricks" -q -f dotnet20 dotnet48 gdiplus_winxp comctl32
     "$HOME/.local/share/osuconfig/winetricks" -q win2k3
     wine reg add "HKEY_CURRENT_USER\Software\Wine\DllOverrides" /v winemenubuilder /t REG_SZ /d ""
 


### PR DESCRIPTION
![2024-06-28_01-47](https://github.com/NelloKudo/osu-winello/assets/17330163/36b4501e-8003-46be-be61-c5948fc0fbbb)
This no longer appears if dotnet20 is in the prefix when wine updates the prefix (e.g. when a new version is installed)

Installing dotnet20 adds about a minute to the `--fixprefix` command, but is probably worth it in order to reduce confusion.

P.S. thank github for adding that important newline