### PR TITLE
Factor out some hardcoded wine paths

### DIFF
--- a/osu-wine
+++ b/osu-wine
@@ -11,7 +11,8 @@ export LAUNCH_ARGS="" # Use this for args like prime-run or gamemoderun!
 export WINEESYNC=1 # Enables esync (when possible)
 export WINEFSYNC=1 # Enables fsync (when possible)
 export WINE_BLOCK_GET_VERSION=1 # Hides wine ver. thanks to oglfreak's patch
-export PATH="$HOME/.local/share/osuconfig/wine-osu/bin:$PATH" # Path to wine-osu
+export WINEPATH="$HOME/.local/share/osuconfig/wine-osu"
+export PATH="$WINEPATH/bin:$PATH" # Path to wine-osu
 export WINEARCH=win64
 export WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix"
 osuinstall=$(</"$HOME/.local/share/osuconfig/osupath")
@@ -262,9 +263,9 @@ case "$1" in
     ;;
 
     '--fixfolders')
-    WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix" wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command"
-    WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix" wine reg delete "HKEY_CLASSES_ROOT\folder\shell\open\ddeexec" /f
-    WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix" wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "/home/$USER/.local/share/osuconfig/folderfixosu xdg-open \"%1\""
+    wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command"
+    wine reg delete "HKEY_CLASSES_ROOT\folder\shell\open\ddeexec" /f
+    wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "/home/$USER/.local/share/osuconfig/folderfixosu xdg-open \"%1\""
     ;;
 
     '--w10fonts')
@@ -319,16 +320,16 @@ EOF
     fi
 
     # Adding fixfolderosu again
-    WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix" wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command"
-    WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix" wine reg delete "HKEY_CLASSES_ROOT\folder\shell\open\ddeexec" /f
-    WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix" wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "/home/$USER/.local/share/osuconfig/folderfixosu xdg-open \"%1\""
+    wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command"
+    wine reg delete "HKEY_CLASSES_ROOT\folder\shell\open\ddeexec" /f
+    wine reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "/home/$USER/.local/share/osuconfig/folderfixosu xdg-open \"%1\""
 
     if [ ! -d "$WINEPREFIX/drive_c/winestreamproxy" ] ; then
         Info "Configuring Winestreamproxy (Discord RPC)"
         wget --no-check-certificate "https://github.com/openglfreak/winestreamproxy/releases/download/v2.0.3/winestreamproxy-2.0.3-amd64.tar.gz" --output-document "/tmp/winestreamproxy-2.0.3-amd64.tar.gz"
         mkdir -p "/tmp/winestreamproxy"
         tar -xf "/tmp/winestreamproxy-2.0.3-amd64.tar.gz" -C "/tmp/winestreamproxy"
-        WINE="$HOME/.local/share/osuconfig/wine-osu/bin/wine" bash "/tmp/winestreamproxy/install.sh"
+        WINE="$WINEPATH/bin/wine" bash "/tmp/winestreamproxy/install.sh"
         rm -f "/tmp/winestreamproxy-2.0.3-amd64.tar.gz"
         rm -rf "/tmp/winestreamproxy"
     fi


### PR DESCRIPTION
Tiny QOL change for the `osu-wine` script. Removes a hardcoded path to the wine binary in `--fixprefix`, fixing a footgun for people editing the path exports at the top of the script (which would e.g. break winestreamproxy if someone edited the `export PATH=...` line to point to a custom wine and ran `--fixprefix`). Also removes some hardcoded `WINEPREFIX` overrides for the same reason.