### PR TITLE
Corrected readme for arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can easily install them like this:
 
 **Ubuntu/Debian:** `sudo apt install -y git wget zenity xdg-desktop-portal`
 
-**Arch Linux:** `sudo pacman -Sy --needed  --noconfirm git wget zenity xdg-desktop-portal`
+**Arch Linux:** `sudo pacman -Syu --needed  --noconfirm git wget zenity xdg-desktop-portal`
 
 **Fedora:** `sudo dnf install -y git wget zenity xdg-desktop-portal`
 


### PR DESCRIPTION
Hello,
To make the readme a bit less error prone for novice users: [`pacman -Sy` is unsupported, `pacman -Syu` should be used instead](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported)