### PR TITLE
Replace windows release of tosu to linux release

### DIFF
--- a/osu-wine
+++ b/osu-wine
@@ -233,14 +233,13 @@ case "$1" in
     '--tosu')
     if [ ! -d "$HOME/.local/share/osuconfig/tosu" ]; then
         git -C "$HOME/.local/share/osuconfig/update" pull --quiet
-        bash "$HOME/.local/share/osuconfig/update/osu-winello.sh" tosu
+        bash "$HOME/.local/share/osuconfig/update/osu-winello.sh" && tosu
     fi
 
     Info "Launching tosu..."
-    # tosu / gosumemory don't work with umu-run, so we always make sure that osu! is already running first
-    # to make sure a wineserver is already up and tosu won't rely on system libraries but on umu-run's runtime.
     $LAUNCH_ARGS "$UMU_RUN" "$OSUPATH/osu!.exe" > /dev/null 2>&1 &
-    NODE_SKIP_PLATFORM_CHECK=1 WINEDEBUG=-all "$WINE_PATH" "$HOME/.local/share/osuconfig/tosu/tosu.exe"
+    cd $HOME
+    $HOME/.local/share/osuconfig/tosu/tosu
     ;;
 
     '--info')

--- a/osu-wine
+++ b/osu-wine
@@ -229,8 +229,21 @@ case "$1" in
     $LAUNCH_ARGS "$UMU_RUN" "$OSUPATH/osu!.exe" > /dev/null 2>&1 &
     WINEDEBUG=-all "$WINE_PATH" "$HOME/.local/share/osuconfig/gosumemory/gosumemory.exe"
     ;;
-
+    
     '--tosu')
+    if [ ! -d "$HOME/.local/share/osuconfig/tosu" ]; then
+        git -C "$HOME/.local/share/osuconfig/update" pull --quiet
+        bash "$HOME/.local/share/osuconfig/update/osu-winello.sh" tosu
+    fi
+
+    Info "Launching tosu..."
+    # tosu / gosumemory don't work with umu-run, so we always make sure that osu! is already running first
+    # to make sure a wineserver is already up and tosu won't rely on system libraries but on umu-run's runtime.
+    $LAUNCH_ARGS "$UMU_RUN" "$OSUPATH/osu!.exe" > /dev/null 2>&1 &
+    NODE_SKIP_PLATFORM_CHECK=1 WINEDEBUG=-all "$WINE_PATH" "$HOME/.local/share/osuconfig/tosu/tosu.exe"
+    ;;
+    
+    '--tosu-linux')
     if [ ! -d "$HOME/.local/share/osuconfig/tosu" ]; then
         git -C "$HOME/.local/share/osuconfig/update" pull --quiet
         bash "$HOME/.local/share/osuconfig/update/osu-winello.sh" && tosu

--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -526,6 +526,18 @@ function Gosumemory(){
 }
 
 function tosu(){
+    TOSU_LINK="https://github.com/KotRikD/tosu/releases/download/v3.3.1/tosu-windows-v3.3.1.zip"
+    
+    if [ ! -d "$HOME/.local/share/osuconfig/tosu" ]; then
+        Info "Installing tosu.."
+        mkdir -p "$HOME/.local/share/osuconfig/tosu"
+        wget -O "/tmp/tosu.zip" "$TOSU_LINK" || Error "Download failed, check your connection.."
+        unzip -d "$HOME/.local/share/osuconfig/tosu" -q "/tmp/tosu.zip"
+        rm "/tmp/tosu.zip"
+    fi
+}   
+
+function tosu-linux(){
     TOSU_LINK="https://github.com/KotRikD/tosu/releases/download/v3.3.1/tosu-linux-v3.3.1.zip"
     
     if [ ! -d "$HOME/.local/share/osuconfig/tosu" ]; then

--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -526,7 +526,7 @@ function Gosumemory(){
 }
 
 function tosu(){
-    TOSU_LINK="https://github.com/KotRikD/tosu/releases/download/v3.3.1/tosu-windows-v3.3.1.zip"
+    TOSU_LINK="https://github.com/KotRikD/tosu/releases/download/v3.3.1/tosu-linux-v3.3.1.zip"
     
     if [ ! -d "$HOME/.local/share/osuconfig/tosu" ]; then
         Info "Installing tosu.."
@@ -534,6 +534,7 @@ function tosu(){
         wget -O "/tmp/tosu.zip" "$TOSU_LINK" || Error "Download failed, check your connection.."
         unzip -d "$HOME/.local/share/osuconfig/tosu" -q "/tmp/tosu.zip"
         rm "/tmp/tosu.zip"
+        chmod +x ~/.local/share/osuconfig/tosu/tosu
     fi
 }   
 


### PR DESCRIPTION
I tried to test the tosu Windows release from the osu-winello update and the tosu Linux release. All of them work fine.

KotRikD said that [tosu on Linux doesn't require running as root](https://github.com/NelloKudo/osu-winello/pull/98#issuecomment-2384997269), and that's true. So, I tried to integrate the Linux version into osu-winello, and that works.

You can see it below:

https://github.com/user-attachments/assets/69a55151-e2e9-457a-8bef-86efc0dff2f5

I think the tosu Linux version would be better than the Windows version because it runs natively, not through umu-run.