### PR TITLE
osu-wine: Set WINE_BLOCK_GET_VERSION=0 by default.

### DIFF
--- a/osu-wine
+++ b/osu-wine
@@ -20,7 +20,7 @@ export WINETRICKS_PATH="$PROTONPATH/protontricks/winetricks"
 export GAMEID="osu-wine-umu"
 UMU_RUN="$PROTONPATH/umu-run"
 
-export WINE_BLOCK_GET_VERSION=1 # Hides wine ver. thanks to oglfreak's patch
+export WINE_BLOCK_GET_VERSION=0 # Hides wine ver. thanks to oglfreak's patch
 export WINEARCH=win64
 export WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix"
 osuinstall=$(</"$HOME/.local/share/osuconfig/osupath")


### PR DESCRIPTION
Might fix issues related to #109, it does for me but others report no change...
WINE_BLOCK_GET_VERSION=1 crashes no matter what Windows version I set in winecfg or what wine version I use. There must have been an osu!auth.dll update which causes problems when the Windows version is used.