### PR TITLE
Respect the user's $XDG_DATA_HOME, and allow for a custom binary directory through $BINDIR

### DIFF
--- a/osu-wine
+++ b/osu-wine
@@ -10,15 +10,18 @@ LAUNCH_ARGS="env PROTONFIXES_DISABLE=1" # Use this for args like prime-run or ga
 export PRESSURE_VESSEL_FILESYSTEMS_RW=${PRESSURE_VESSEL_FILESYSTEMS_RW:-} # Set this to your external disk paths if you use symlinks!
 export WINEDEBUG=${WINEDEBUG:-}
 
-export PROTONPATH="$HOME/.local/share/osuconfig/proton-osu"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export BINDIR="${BINDIR:-$HOME/.local/bin}"
+
+export PROTONPATH="$XDG_DATA_HOME/osuconfig/proton-osu"
 export WINESERVER_PATH="$PROTONPATH/files/bin/wineserver"
 export WINE_PATH="$PROTONPATH/files/bin/wine"
 export WINETRICKS_PATH="$PROTONPATH/protontricks/winetricks"
 export GAMEID="umu-727"
 UMU_RUN="$PROTONPATH/umu-run"
 
-export WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix"
-osuinstall=$(</"$HOME/.local/share/osuconfig/osupath")
+export WINEPREFIX="$XDG_DATA_HOME/wineprefixes/osu-wineprefix"
+osuinstall=$(</"$XDG_DATA_HOME/osuconfig/osupath")
 export OSUPATH="$osuinstall"
 
 export vblank_mode=0            # Disables vsync for mesa
@@ -66,8 +69,8 @@ function Help(){
 }
 
 function Checkshort(){      # Deletes useless shortcuts created when installing
-    if [ -e "$HOME/.local/share/applications/wine/Programs/osu!.desktop" ] ; then
-        rm -f "$HOME/.local/share/applications/wine/Programs/osu!.desktop" ; fi
+    if [ -e "$XDG_DATA_HOME/applications/wine/Programs/osu!.desktop" ] ; then
+        rm -f "$XDG_DATA_HOME/applications/wine/Programs/osu!.desktop" ; fi
 
     DESKTOPDIR=$(xdg-user-dir DESKTOP)
     if [ -e "$DESKTOPDIR/osu!.lnk" ] ; then
@@ -76,8 +79,8 @@ function Checkshort(){      # Deletes useless shortcuts created when installing
 
 function SelfUpdate() {
     local self="$1"
-    local update_source="${HOME}/.local/share/osuconfig/update/osu-wine"
-    local backup_path="${HOME}/.local/share/osuconfig/osu-wine.bak"
+    local update_source="$XDG_DATA_HOME/osuconfig/update/osu-wine"
+    local backup_path="$XDG_DATA_HOME/osuconfig/osu-wine.bak"
 
     if [ ! -f "$update_source" ]; then
         Warning "Update source not found: $update_source"
@@ -115,8 +118,8 @@ function Update(){
     Info "Checking for Steam Runtime updates first.."
     $LAUNCH_ARGS "$UMU_RUN" wineboot -u
     $LAUNCH_ARGS "$WINESERVER_PATH" -k
-    git -C "${HOME}/.local/share/osuconfig/update" pull --quiet
-    bash "${HOME}/.local/share/osuconfig/update/osu-winello.sh" update
+    git -C "$XDG_DATA_HOME/osuconfig/update" pull --quiet
+    bash "$XDG_DATA_HOME/osuconfig/update/osu-winello.sh" update
 
     local self
     self="$(realpath "$0")"
@@ -124,20 +127,20 @@ function Update(){
     if [ ! -w "${self}" ]; then
         Warning "Note: ${self} is not writable - updating the osu-wine launcher will not be possible"
         Warning "Try running the update with appropriate permissions if you want to update the launcher,"
-        Warning "   or move it to a place like ${HOME}/.local/bin and then run it from there."
+        Warning "   or move it to a place like $BINDIR and then run it from there."
         return
     fi
 
     Info "Do you want to update the 'osu-wine' launcher as well?"
     Info "This is recommended, as there may be important fixes and updates."
     Warning "This will remove any customizations you might have made to ${self},"
-    Warning "   but a backup will be left in ${HOME}/.local/share/osuconfig/osu-wine.bak ."
+    Warning "   but a backup will be left in $XDG_DATA_HOME/osuconfig/osu-wine.bak ."
 
     read -r -p "$(Info "Update the 'osu-wine' launcher? (y/N) ")" selfupdate
     if [ "${selfupdate}" = 'y' ] || [ "${selfupdate}" = 'Y' ]; then
         if SelfUpdate "${self}"; then
             Info "Launcher update successful!"
-            Info "Backup saved to: ${HOME}/.local/share/osuconfig/osu-wine.bak"
+            Info "Backup saved to: $XDG_DATA_HOME/osuconfig/osu-wine.bak"
         else
             Error "Launcher update failed"
         fi
@@ -154,13 +157,13 @@ function longPathsFix(){
 
 function SetupReader(){
     local READER_NAME="${1}"
-    if [ ! -d "$HOME/.local/share/osuconfig/$READER_NAME" ]; then
-        git -C "$HOME/.local/share/osuconfig/update" pull --quiet
-        bash "$HOME/.local/share/osuconfig/update/osu-winello.sh" "$READER_NAME"
+    if [ ! -d "$XDG_DATA_HOME/osuconfig/$READER_NAME" ]; then
+        git -C "$XDG_DATA_HOME/osuconfig/update" pull --quiet
+        bash "$XDG_DATA_HOME/osuconfig/update/osu-winello.sh" "$READER_NAME"
     fi
 
     Info "Setting up $READER_NAME wrapper..."
-    READER_PATH="$($LAUNCH_ARGS PROTON_VERB=runinprefix "$UMU_RUN" winepath -w "$HOME/.local/share/osuconfig/$READER_NAME/$READER_NAME.exe")"
+    READER_PATH="$($LAUNCH_ARGS PROTON_VERB=runinprefix "$UMU_RUN" winepath -w "$XDG_DATA_HOME/osuconfig/$READER_NAME/$READER_NAME.exe")"
     OSU_PATH="$($LAUNCH_ARGS PROTON_VERB=runinprefix "$UMU_RUN" winepath -w "$OSUPATH/osu!.exe")"
     OSU_DIR="$($LAUNCH_ARGS PROTON_VERB=runinprefix "$UMU_RUN" winepath -w "$OSUPATH")"
 
@@ -199,7 +202,7 @@ function LaunchGame() {
     if [ -n "$1" ]; then POST_COMMAND+=("-devserver" "${1}"); fi
 
     export PROTON_LOG=1 # only want to redirect to a file for the game
-    export PROTON_LOG_DIR="$HOME/.local/share/osuconfig/"
+    export PROTON_LOG_DIR="$XDG_DATA_HOME/osuconfig/"
     export WINEDEBUG="+timestamp,+pid,+tid,+seh,+unwind,+threadname,+debugstr,+loaddll,+winebrowser,+exec ${WINEDEBUG:-}"
 
     Info "Launching ${PRE_COMMAND[*]} ${POST_COMMAND[*]} !"
@@ -254,7 +257,7 @@ case "$1" in
                 read -r -p "$(Info "Are you sure? This will delete your files! (y/N)")" dirchoice2
 
                     if [ "$dirchoice2" = 'y' ] || [ "$dirchoice2" = 'Y' ]; then
-                        lastdir=$(</"$HOME/.local/share/osuconfig/osupath")
+                        lastdir=$(</"$XDG_DATA_HOME/osuconfig/osupath")
                         rm -rf "$lastdir/osu!" && Info "Cleaning done!"
                     else
                         Info "Skipping..."
@@ -268,19 +271,19 @@ case "$1" in
     Info "Please choose your new directory:"
 
     newdir="$(zenity --file-selection --directory)"
-    lastdir=$(</"$HOME/.local/share/osuconfig/osupath")
+    lastdir=$(</"$XDG_DATA_HOME/osuconfig/osupath")
 
     if [ ! -d "$newdir" ]; then
         Error "No folder selected, please make sure zenity is installed.."
     fi
 
-    rm -f "$HOME/.local/share/osuconfig/osupath"
+    rm -f "$XDG_DATA_HOME/osuconfig/osupath"
     if [ -d "$newdir/osu!" ] || [ -s "$newdir/osu!.exe" ]; then
         Info "osu! folder/game already exists: skipping.."
 
         if [ -d "$newdir/osu!" ]; then
             OSUPATH="$newdir/osu!"
-            echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+            echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
 
             Info "Change done from '$lastdir' to '$newdir'!"
             deleteFolder
@@ -288,7 +291,7 @@ case "$1" in
 
         if [ -s "$newdir/osu!.exe" ]; then
             OSUPATH="$newdir"
-            echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+            echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
 
             Info "Change done from '$lastdir' to '$newdir'!"
             deleteFolder
@@ -296,7 +299,7 @@ case "$1" in
     else
         mkdir "$newdir/osu!"
         OSUPATH="$newdir/osu!"
-        echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+        echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
 
         Info "Downloading osu! to your new install.."
         wget -O "$OSUPATH/osu!.exe" "http://m1.ppy.sh/r/osu!install.exe" && wgetcheck6="$?"
@@ -315,7 +318,7 @@ case "$1" in
 ###################################################################################################
 
     '--remove')
-    bash "$HOME/.local/share/osuconfig/update/osu-winello.sh" uninstall
+    bash "$XDG_DATA_HOME/osuconfig/update/osu-winello.sh" uninstall
     ;;
 
 ###################################################################################################
@@ -341,20 +344,20 @@ case "$1" in
     '--fixfolders')
     $LAUNCH_ARGS "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command"
     $LAUNCH_ARGS "$UMU_RUN" reg delete "HKEY_CLASSES_ROOT\folder\shell\open\ddeexec" /f
-    $LAUNCH_ARGS "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "/home/$USER/.local/share/osuconfig/folderfixosu xdg-open \"%1\""
+    $LAUNCH_ARGS "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "$XDG_DATA_HOME/osuconfig/folderfixosu xdg-open \"%1\""
     ;;
 
 ###################################################################################################
 
     *fix*umu*)
-    git -C "$HOME/.local/share/osuconfig/update" pull --quiet
-    bash "/$HOME/.local/share/osuconfig/update/osu-winello.sh" fixumu
+    git -C "$XDG_DATA_HOME/osuconfig/update" pull --quiet
+    bash "$XDG_DATA_HOME/osuconfig/update/osu-winello.sh" fixumu
     ;;
 
 ###################################################################################################
 
     '--fixrpc')
-    if [ ! -d "$HOME/.local/share/wineprefixes/osu-wineprefix/drive_c/windows/bridge.exe" ] ; then
+    if [ ! -d "$XDG_DATA_HOME/wineprefixes/osu-wineprefix/drive_c/windows/bridge.exe" ] ; then
         Info "Configuring rpc-bridge (Discord RPC)"
         wget -O "/tmp/bridge.zip" "https://github.com/EnderIce2/rpc-bridge/releases/download/v1.2/bridge.zip" && chk="$?"
 
@@ -375,7 +378,7 @@ case "$1" in
 
     '--osuhandler')
 
-    OSUHANDLERPATH="$HOME/.local/share/osuconfig/osu-handler-wine"
+    OSUHANDLERPATH="$XDG_DATA_HOME/osuconfig/osu-handler-wine"
 
     Info "Trying to load your file/link.."
     case "$2" in
@@ -410,7 +413,7 @@ case "$1" in
     Info "Deleting old Wineprefix..."
     rm -rf "$WINEPREFIX"
 
-    export WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix"
+    export WINEPREFIX="$XDG_DATA_HOME/wineprefixes/osu-wineprefix"
 
     WINEESYNC=0 WINEFSYNC=0 PROTON_NO_ESYNC=1 PROTON_NO_FSYNC=1 "$UMU_RUN" \
     winetricks dotnet20 dotnet48 gdiplus_winxp win2k3
@@ -418,17 +421,17 @@ case "$1" in
     # Adding fixfolderosu again
     $LAUNCH_ARGS "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command"
     $LAUNCH_ARGS "$UMU_RUN" reg delete "HKEY_CLASSES_ROOT\folder\shell\open\ddeexec" /f
-    $LAUNCH_ARGS "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "/home/$USER/.local/share/osuconfig/folderfixosu xdg-open \"%1\""
+    $LAUNCH_ARGS "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "$XDG_DATA_HOME/osuconfig/folderfixosu xdg-open \"%1\""
 
     # Applying fix for long names/paths...
     longPathsFix
 
     # Fix to importing maps/skins/osu links after Stable update 20250122.1
     # This assumes the osu! folder is mounted at the D: drive (which Winello does just a line above)
-    REGFILE="$HOME/.local/share/osuconfig/osu-handler.reg"
+    REGFILE="$XDG_DATA_HOME/osuconfig/osu-handler.reg"
     "$UMU_RUN" regedit /s "${REGFILE}"
 
-    if [ ! -d "$HOME/.local/share/wineprefixes/osu-wineprefix/drive_c/windows/bridge.exe" ] ; then
+    if [ ! -d "$XDG_DATA_HOME/wineprefixes/osu-wineprefix/drive_c/windows/bridge.exe" ] ; then
         Info "Configuring rpc-bridge (Discord RPC)"
         wget -O "/tmp/bridge.zip" "https://github.com/EnderIce2/rpc-bridge/releases/download/v1.2/bridge.zip" && chk="$?"
 
@@ -474,7 +477,7 @@ case "$1" in
     Wineprefix location: $WINEPREFIX
     osu! folder: '$OSUPATH'
 
-    If you need to add more options to osu!, see around line 77 of the script (ex. nano ~/.local/bin/osu-wine)
+    If you need to add more options to osu!, see around line 77 of the script (ex. nano $BINDIR/osu-wine)
     You can run 'osu-wine --help' to see all the script's functions (fix prefix, w10 fonts etc.)
     You can find more troubleshooting and info at here: https://osu.ppy.sh/community/forums/topics/1248084?n=1
 

--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -17,6 +17,8 @@ LASTPROTONVERSION=0
 # Proton-osu mirrors
 PROTONLINK="https://github.com/whrvt/umubuilder/releases/download/proton-osu-$MAJOR-$MINOR/proton-osu-$MAJOR-$MINOR.tar.xz"
 
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export BINDIR="${BINDIR:-$HOME/.local/bin}"
 
 #   =====================================
 #   =====================================
@@ -42,16 +44,16 @@ function Quit(){
 # Function to revert the install in case of any type of fail
 function Revert(){
     echo -e '\033[1;31m'"Reverting install...:\033[0m"
-    rm -f "$HOME/.local/share/icons/osu-wine.png"
-    rm -f "$HOME/.local/share/applications/osu-wine.desktop"
-    rm -f "$HOME/.local/bin/osu-wine"
-    rm -rf "$HOME/.local/share/osuconfig"
+    rm -f "$XDG_DATA_HOME/icons/osu-wine.png"
+    rm -f "$XDG_DATA_HOME/applications/osu-wine.desktop"
+    rm -f "$BINDIR/osu-wine"
+    rm -rf "$XDG_DATA_HOME/osuconfig"
     rm -f "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz"
     rm -f "/tmp/osu-mime.tar.xz"
     rm -rf "/tmp/osu-mime"
-    rm -f "$HOME/.local/share/mime/packages/osuwinello-file-extensions.xml"
-    rm -f "$HOME/.local/share/applications/osuwinello-file-extensions-handler.desktop"
-    rm -f "$HOME/.local/share/applications/osuwinello-url-handler.desktop"
+    rm -f "$XDG_DATA_HOME/mime/packages/osuwinello-file-extensions.xml"
+    rm -f "$XDG_DATA_HOME/applications/osuwinello-file-extensions-handler.desktop"
+    rm -f "$XDG_DATA_HOME/applications/osuwinello-url-handler.desktop"
     rm -f "/tmp/winestreamproxy-2.0.3-amd64.tar.xz"
     rm -rf "/tmp/winestreamproxy"
     echo -e '\033[1;31m'"Reverting done, try again with ./osu-winello.sh\033[0m"
@@ -72,7 +74,7 @@ function InitialSetup(){
 
     # Checking for previous versions of osu-wine (mine or DiamondBurned's)
     if [ -e /usr/bin/osu-wine ] ; then Quit "Please uninstall old osu-wine (/usr/bin/osu-wine) before installing!"; fi
-    if [ -e "$HOME/.local/bin/osu-wine" ] ; then Quit "Please uninstall Winello (osu-wine --remove) before installing!" ; fi
+    if [ -e "$BINDIR/osu-wine" ] ; then Quit "Please uninstall Winello (osu-wine --remove) before installing!" ; fi
 
     Info "Welcome to the script! Follow it to install osu! 8)"
 
@@ -85,26 +87,26 @@ function InitialSetup(){
         fi
     fi
 
-    # Checking if ~/.local/bin is in PATH:
-    mkdir -p "$HOME/.local/bin"
-    pathcheck=$(echo "$PATH" | grep -q "$HOME/.local/bin" && echo "y")
+    # Checking if $BINDIR is in PATH:
+    mkdir -p "$BINDIR"
+    pathcheck=$(echo "$PATH" | grep -q "$BINDIR" && echo "y")
 
-    # If ~/.local/bin is not in PATH:
+    # If $BINDIR is not in PATH:
     if [ "$pathcheck" != "y" ] ; then
         
         if grep -q "bash" "$SHELL" ; then
             touch -a "$HOME/.bashrc"
-            echo "export PATH=$HOME/.local/bin:$PATH" >> "$HOME/.bashrc"
+            echo "export PATH=$BINDIR:$PATH" >> "$HOME/.bashrc"
         fi
 
         if grep -q "zsh" "$SHELL" ; then
             touch -a "$HOME/.zshrc"
-            echo "export PATH=$HOME/.local/bin:$PATH" >> "$HOME/.zshrc"
+            echo "export PATH=$BINDIR:$PATH" >> "$HOME/.zshrc"
         fi
 
         if grep -q "fish" "$SHELL" ; then
             mkdir -p "$HOME/.config/fish" && touch -a "$HOME/.config/fish/config.fish"
-            fish_add_path ~/.local/bin/
+            fish_add_path "$BINDIR/"
         fi
     fi
 
@@ -160,28 +162,28 @@ profile bwrap /usr/bin/bwrap flags=(unconfined) {
 function InstallProton(){
     
     Info "Installing game script:"
-    cp ./osu-wine "$HOME/.local/bin/osu-wine" && chmod +x "$HOME/.local/bin/osu-wine"
+    cp ./osu-wine "$BINDIR/osu-wine" && chmod +x "$BINDIR/osu-wine"
 
     Info "Installing icons:"
-    mkdir -p "$HOME/.local/share/icons"    
-    cp "./stuff/osu-wine.png" "$HOME/.local/share/icons/osu-wine.png" && chmod 644 "$HOME/.local/share/icons/osu-wine.png"
+    mkdir -p "$XDG_DATA_HOME/icons"    
+    cp "./stuff/osu-wine.png" "$XDG_DATA_HOME/icons/osu-wine.png" && chmod 644 "$XDG_DATA_HOME/icons/osu-wine.png"
 
     Info "Installing .desktop:"
-    mkdir -p "$HOME/.local/share/applications"
+    mkdir -p "$XDG_DATA_HOME/applications"
     echo "[Desktop Entry]
 Name=osu!
 Comment=osu! - Rhythm is just a *click* away!
 Type=Application
-Exec=$HOME/.local/bin/osu-wine %U
-Icon=$HOME/.local/share/icons/osu-wine.png
+Exec=$BINDIR/osu-wine %U
+Icon=$XDG_DATA_HOME/icons/osu-wine.png
 Terminal=false
-Categories=Wine;Game;" | tee "$HOME/.local/share/applications/osu-wine.desktop" >/dev/null
-    chmod +x "$HOME/.local/share/applications/osu-wine.desktop"
+Categories=Wine;Game;" | tee "$XDG_DATA_HOME/applications/osu-wine.desktop" >/dev/null
+    chmod +x "$XDG_DATA_HOME/applications/osu-wine.desktop"
 
-    if [ -d "$HOME/.local/share/osuconfig" ]; then
+    if [ -d "$XDG_DATA_HOME/osuconfig" ]; then
         Info "Skipping osuconfig.."
     else
-        mkdir "$HOME/.local/share/osuconfig"
+        mkdir "$XDG_DATA_HOME/osuconfig"
     fi
 
     Info "Installing Proton-osu:"
@@ -193,20 +195,20 @@ Categories=Wine;Game;" | tee "$HOME/.local/share/applications/osu-wine.desktop" 
     fi
 
     # This will extract Proton-osu and set last version to the one downloaded
-    tar -xf "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz" -C "$HOME/.local/share/osuconfig"
+    tar -xf "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz" -C "$XDG_DATA_HOME/osuconfig"
     LASTPROTONVERSION="$PROTONVERSION"
     rm -f "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz"
 
     # The update function works under this folder: it compares variables from files stored in osuconfig 
     # with latest values from GitHub and check whether to update or not
     Info "Installing script copy for updates.."
-    mkdir -p "$HOME/.local/share/osuconfig/update"
-    git clone https://github.com/NelloKudo/osu-winello.git "$HOME/.local/share/osuconfig/update" || Error "Git failed, check your connection.."
-    echo "$LASTPROTONVERSION" >> "$HOME/.local/share/osuconfig/protonverupdate"
+    mkdir -p "$XDG_DATA_HOME/osuconfig/update"
+    git clone https://github.com/NelloKudo/osu-winello.git "$XDG_DATA_HOME/osuconfig/update" || Error "Git failed, check your connection.."
+    echo "$LASTPROTONVERSION" >> "$XDG_DATA_HOME/osuconfig/protonverupdate"
 
     ## Setting up umu-launcher from the Proton package
     Info "Setting up umu-launcher.."
-    UMU_RUN="$HOME/.local/share/osuconfig/proton-osu/umu-run"
+    UMU_RUN="$XDG_DATA_HOME/osuconfig/proton-osu/umu-run"
     export GAMEID="umu-727"
 }
 
@@ -215,7 +217,7 @@ function ConfigurePath(){
     
     Info "Configuring osu! folder:"
     Info "Where do you want to install the game?: 
-          1 - Default path (~/.local/share/osu-wine)
+          1 - Default path ($XDG_DATA_HOME/osu-wine)
           2 - Custom path"
     read -r -p "$(Info "Choose your option: ")" installpath
     
@@ -225,16 +227,16 @@ function ConfigurePath(){
         
         '1')  
             
-            mkdir -p "$HOME/.local/share/osu-wine"
-            GAMEDIR="$HOME/.local/share/osu-wine"
+            mkdir -p "$XDG_DATA_HOME/osu-wine"
+            GAMEDIR="$XDG_DATA_HOME/osu-wine"
             
             if [ -d "$GAMEDIR/OSU" ]; then
                 OSUPATH="$GAMEDIR/OSU"
-                echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+                echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
             else
                 mkdir -p "$GAMEDIR/osu!"
                 OSUPATH="$GAMEDIR/osu!"
-                echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+                echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
             fi
         ;;
         
@@ -245,11 +247,11 @@ function ConfigurePath(){
         
             if [ -e "$GAMEDIR/osu!.exe" ]; then
                 OSUPATH="$GAMEDIR"
-                echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath" 
+                echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath" 
             else
                 mkdir -p "$GAMEDIR/osu!"
                 OSUPATH="$GAMEDIR/osu!"
-                echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+                echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
             fi
         ;;
      
@@ -257,18 +259,18 @@ function ConfigurePath(){
 
     else
     
-        Info "No option chosen, installing to default.. (~/.local/share/osu-wine)"
+        Info "No option chosen, installing to default.. ($XDG_DATA_HOME/osu-wine)"
 
-        mkdir -p "$HOME/.local/share/osu-wine"
-        GAMEDIR="$HOME/.local/share/osu-wine"
+        mkdir -p "$XDG_DATA_HOME/osu-wine"
+        GAMEDIR="$XDG_DATA_HOME/osu-wine"
         
         if [ -d "$GAMEDIR/OSU" ]; then
             OSUPATH="$GAMEDIR/OSU"
-            echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+            echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
         else
             mkdir -p "$GAMEDIR/osu!"
             OSUPATH="$GAMEDIR/osu!"
-            echo "$OSUPATH" > "$HOME/.local/share/osuconfig/osupath"
+            echo "$OSUPATH" > "$XDG_DATA_HOME/osuconfig/osupath"
         fi
 
     fi
@@ -294,70 +296,70 @@ function FullInstall(){
     fi
     
     tar -xf "/tmp/osu-mime.tar.gz" -C "/tmp"
-    mkdir -p "$HOME/.local/share/mime/packages"
-    cp "/tmp/osu-mime/osu-file-extensions.xml" "$HOME/.local/share/mime/packages/osuwinello-file-extensions.xml"
-    update-mime-database "$HOME/.local/share/mime"
+    mkdir -p "$XDG_DATA_HOME/mime/packages"
+    cp "/tmp/osu-mime/osu-file-extensions.xml" "$XDG_DATA_HOME/mime/packages/osuwinello-file-extensions.xml"
+    update-mime-database "$XDG_DATA_HOME/mime"
     rm -f "/tmp/osu-mime.tar.gz"
     rm -rf "/tmp/osu-mime"
     
     # Installing osu-handler from https://github.com/openglfreak/osu-handler-wine / https://aur.archlinux.org/packages/osu-handler
     # Binary was compiled from source on Ubuntu 18.04
-    wget -O "$HOME/.local/share/osuconfig/osu-handler-wine" "https://github.com/NelloKudo/osu-winello/raw/main/stuff/osu-handler-wine" && chk="$?"
+    wget -O "$XDG_DATA_HOME/osuconfig/osu-handler-wine" "https://github.com/NelloKudo/osu-winello/raw/main/stuff/osu-handler-wine" && chk="$?"
     
     if [ ! "$chk" = 0 ] ; then
         Info "wget failed; trying with --no-check-certificate.."
-        wget --no-check-certificate -O "$HOME/.local/share/osuconfig/osu-handler-wine" "https://github.com/NelloKudo/osu-winello/raw/main/stuff/osu-handler-wine" || Error "Download failed, check your connection or open an issue here: https://github.com/NelloKudo/osu-winello/issues"
+        wget --no-check-certificate -O "$XDG_DATA_HOME/osuconfig/osu-handler-wine" "https://github.com/NelloKudo/osu-winello/raw/main/stuff/osu-handler-wine" || Error "Download failed, check your connection or open an issue here: https://github.com/NelloKudo/osu-winello/issues"
     fi
     
-    chmod +x "$HOME/.local/share/osuconfig/osu-handler-wine"
+    chmod +x "$XDG_DATA_HOME/osuconfig/osu-handler-wine"
 
     # Creating entries for those two
     echo "[Desktop Entry]
 Type=Application
 Name=osu!
 MimeType=application/x-osu-skin-archive;application/x-osu-replay;application/x-osu-beatmap-archive;
-Exec=$HOME/.local/bin/osu-wine --osuhandler %f
+Exec=$BINDIR/osu-wine --osuhandler %f
 NoDisplay=true
 StartupNotify=true
-Icon=$HOME/.local/share/icons/osu-wine.png" | tee "$HOME/.local/share/applications/osuwinello-file-extensions-handler.desktop"
-    chmod +x "$HOME/.local/share/applications/osuwinello-file-extensions-handler.desktop" >/dev/null
+Icon=$XDG_DATA_HOME/icons/osu-wine.png" | tee "$XDG_DATA_HOME/applications/osuwinello-file-extensions-handler.desktop"
+    chmod +x "$XDG_DATA_HOME/applications/osuwinello-file-extensions-handler.desktop" >/dev/null
 
     echo "[Desktop Entry]
 Type=Application
 Name=osu!
 MimeType=x-scheme-handler/osu;
-Exec=$HOME/.local/bin/osu-wine --osuhandler %u
+Exec=$BINDIR/osu-wine --osuhandler %u
 NoDisplay=true
 StartupNotify=true
-Icon=$HOME/.local/share/icons/osu-wine.png" | tee "$HOME/.local/share/applications/osuwinello-url-handler.desktop"
-    chmod +x "$HOME/.local/share/applications/osuwinello-url-handler.desktop" >/dev/null
-    update-desktop-database "$HOME/.local/share/applications"
+Icon=$XDG_DATA_HOME/icons/osu-wine.png" | tee "$XDG_DATA_HOME/applications/osuwinello-url-handler.desktop"
+    chmod +x "$XDG_DATA_HOME/applications/osuwinello-url-handler.desktop" >/dev/null
+    update-desktop-database "$XDG_DATA_HOME/applications"
 
 
     # Time to install my prepackaged Wineprefix, which works in most cases
     # The script is still bundled with osu-wine --fixprefix, which should do the job for me as well
 
     PREFIXLINK="https://gitlab.com/NelloKudo/osu-winello-prefix/-/raw/master/osu-winello-prefix.tar.xz"
-    export PROTONPATH="$HOME/.local/share/osuconfig/proton-osu"
+    export PROTONPATH="$XDG_DATA_HOME/osuconfig/proton-osu"
 
     Info "Configuring Wineprefix:"
 
     # Variable to check if download finished properly
     failprefix="false"
 
-    mkdir -p "$HOME/.local/share/wineprefixes"
-    if [ -d "$HOME/.local/share/wineprefixes/osu-wineprefix" ] ; then
+    mkdir -p "$XDG_DATA_HOME/wineprefixes"
+    if [ -d "$XDG_DATA_HOME/wineprefixes/osu-wineprefix" ] ; then
         
         Info "Wineprefix already exists; do you want to reinstall it?"
         read -r -p "$(Info "Choose: (y/N)")" prefchoice
             
         if [ "$prefchoice" = 'y' ] || [ "$prefchoice" = 'Y' ]; then
-            rm -rf "$HOME/.local/share/wineprefixes/osu-wineprefix"
+            rm -rf "$XDG_DATA_HOME/wineprefixes/osu-wineprefix"
         fi
     fi
 
     # So if there's no prefix (or the user wants to reinstall):
-    if [ ! -d "$HOME/.local/share/wineprefixes/osu-wineprefix" ] ; then
+    if [ ! -d "$XDG_DATA_HOME/wineprefixes/osu-wineprefix" ] ; then
 
         # Downloading prefix in temporary ~/.winellotmp folder
         # to make up for this issue: https://github.com/NelloKudo/osu-winello/issues/36
@@ -372,17 +374,17 @@ Icon=$HOME/.local/share/icons/osu-wine.png" | tee "$HOME/.local/share/applicatio
 
         # Checking whether to create prefix manually or install it from repos
         if [ "$failprefix" = "true" ]; then
-            WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix" "$UMU_RUN" winetricks dotnet20 dotnet48 gdiplus_winxp win2k3
+            WINEPREFIX="$XDG_DATA_HOME/wineprefixes/osu-wineprefix" "$UMU_RUN" winetricks dotnet20 dotnet48 gdiplus_winxp win2k3
         else
-            tar -xf "$HOME/.winellotmp/osu-winello-prefix-umu.tar.xz" -C "$HOME/.local/share/wineprefixes"
-            mv "$HOME/.local/share/wineprefixes/osu-umu" "$HOME/.local/share/wineprefixes/osu-wineprefix" 
+            tar -xf "$HOME/.winellotmp/osu-winello-prefix-umu.tar.xz" -C "$XDG_DATA_HOME/wineprefixes"
+            mv "$XDG_DATA_HOME/wineprefixes/osu-umu" "$XDG_DATA_HOME/wineprefixes/osu-wineprefix" 
         fi 
 
         # Cleaning..
         rm -rf "$HOME/.winellotmp"
 
         # We're now gonna refer to this as Wineprefix
-        export WINEPREFIX="$HOME/.local/share/wineprefixes/osu-wineprefix"
+        export WINEPREFIX="$XDG_DATA_HOME/wineprefixes/osu-wineprefix"
 
         # Time to debloat the prefix a bit and make necessary symlinks (drag and drop, long name maps/paths..)
         rm -rf "$WINEPREFIX/dosdevices"
@@ -394,7 +396,7 @@ Icon=$HOME/.local/share/icons/osu-wine.png" | tee "$HOME/.local/share/applicatio
 
         # Fix to importing maps/skins/osu links after Stable update 20250122.1: https://osu.ppy.sh/home/changelog/stable40/20250122.1
         # This assumes the osu! folder is mounted at the D: drive (which Winello does just a line above)
-        REGFILE="$HOME/.local/share/osuconfig/osu-handler.reg"
+        REGFILE="$XDG_DATA_HOME/osuconfig/osu-handler.reg"
 
 cat > "${REGFILE}" << 'EOF'
 Windows Registry Editor Version 5.00
@@ -505,16 +507,16 @@ EOF
         # Integrating native file explorer by Maot: https://gist.github.com/maotovisk/1bf3a7c9054890f91b9234c3663c03a2
         # This only involves regedit keys.
 
-        cp "./stuff/folderfixosu" "$HOME/.local/share/osuconfig/folderfixosu" && chmod +x "$HOME/.local/share/osuconfig/folderfixosu"
+        cp "./stuff/folderfixosu" "$XDG_DATA_HOME/osuconfig/folderfixosu" && chmod +x "$XDG_DATA_HOME/osuconfig/folderfixosu"
         "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command"
         "$UMU_RUN" reg delete "HKEY_CLASSES_ROOT\folder\shell\open\ddeexec" /f
-        "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "$HOME/.local/share/osuconfig/folderfixosu xdg-open \"%1\""
+        "$UMU_RUN" reg add "HKEY_CLASSES_ROOT\folder\shell\open\command" /f /ve /t REG_SZ /d "$XDG_DATA_HOME/osuconfig/folderfixosu xdg-open \"%1\""
 
     fi
 
     # Installing rpc-bridge for Discord RPC (https://github.com/EnderIce2/rpc-bridge)
 
-    if [ ! -d "$HOME/.local/share/wineprefixes/osu-wineprefix/drive_c/windows/bridge.exe" ] ; then
+    if [ ! -d "$XDG_DATA_HOME/wineprefixes/osu-wineprefix/drive_c/windows/bridge.exe" ] ; then
         Info "Configuring rpc-bridge (Discord RPC)"
         wget -O "/tmp/bridge.zip" "https://github.com/EnderIce2/rpc-bridge/releases/download/v1.2/bridge.zip" && chk="$?"
     
@@ -563,7 +565,7 @@ function Check32(){
     Info "(Window will automatically close after 15 seconds anyways)"
 
     chmod +x "./stuff/glxgears32"
-    UMU_RUN="$HOME/.local/share/osuconfig/proton-osu/umu-run"
+    UMU_RUN="$XDG_DATA_HOME/osuconfig/proton-osu/umu-run"
 
     temp_out=$(mktemp)
 
@@ -614,17 +616,17 @@ function Check32(){
     return 1
 }
 
-# This function reads files located in ~/.local/share/osuconfig
+# This function reads files located in $XDG_DATA_HOME/osuconfig
 # to see whether a new wine-osu version has been released.
 function Update(){
 
     # Checking for old installs with Wine
-    if [ -d "$HOME/.local/share/osuconfig/wine-osu" ]; then
+    if [ -d "$XDG_DATA_HOME/osuconfig/wine-osu" ]; then
         Quit "wine-osu detected and already up-to-date; please reinstall Winello if you want to use proton-osu!"
     fi
 
     # Reading the last version installed
-    LASTPROTONVERSION=$(</"$HOME/.local/share/osuconfig/protonverupdate")
+    LASTPROTONVERSION=$(</"$XDG_DATA_HOME/osuconfig/protonverupdate")
 
     if [ "$LASTPROTONVERSION" \!= "$PROTONVERSION" ]; then
         wget -O "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz" "$PROTONLINK" && chk="$?"
@@ -635,12 +637,12 @@ function Update(){
         fi
         Info "Updating Proton-osu"...
 
-        rm -rf "$HOME/.local/share/osuconfig/proton-osu"
-        tar -xf "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz" -C "$HOME/.local/share/osuconfig"
+        rm -rf "$XDG_DATA_HOME/osuconfig/proton-osu"
+        tar -xf "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz" -C "$XDG_DATA_HOME/osuconfig"
         rm -f "/tmp/proton-osu-${PROTONVERSION}-x86_64.pkg.tar.xz"
         LASTPROTONVERSION="$PROTONVERSION"
-        rm -f "$HOME/.local/share/osuconfig/protonverupdate"
-        echo "$LASTPROTONVERSION" >> "$HOME/.local/share/osuconfig/protonverupdate"
+        rm -f "$XDG_DATA_HOME/osuconfig/protonverupdate"
+        echo "$LASTPROTONVERSION" >> "$XDG_DATA_HOME/osuconfig/protonverupdate"
         Info "Update is completed!"
 
     else
@@ -653,25 +655,25 @@ function Update(){
 function Uninstall(){
 
     Info "Uninstalling icons:"
-    rm -f "$HOME/.local/share/icons/osu-wine.png"
+    rm -f "$XDG_DATA_HOME/icons/osu-wine.png"
     
     Info "Uninstalling .desktop:"
-    rm -f "$HOME/.local/share/applications/osu-wine.desktop"
+    rm -f "$XDG_DATA_HOME/applications/osu-wine.desktop"
     
     Info "Uninstalling game script, utilities & folderfix:"
-    rm -f "$HOME/.local/bin/osu-wine"
-    rm -f "$HOME/.local/bin/folderfixosu"
-    rm -f "$HOME/.local/share/mime/packages/osuwinello-file-extensions.xml"
-    rm -f "$HOME/.local/share/applications/osuwinello-file-extensions-handler.desktop"
-    rm -f "$HOME/.local/share/applications/osuwinello-url-handler.desktop"
+    rm -f "$BINDIR/osu-wine"
+    rm -f "$BINDIR/folderfixosu"
+    rm -f "$XDG_DATA_HOME/mime/packages/osuwinello-file-extensions.xml"
+    rm -f "$XDG_DATA_HOME/applications/osuwinello-file-extensions-handler.desktop"
+    rm -f "$XDG_DATA_HOME/applications/osuwinello-url-handler.desktop"
 
     Info "Uninstalling proton-osu:"
-    rm -rf "$HOME/.local/share/osuconfig/proton-osu"
+    rm -rf "$XDG_DATA_HOME/osuconfig/proton-osu"
     
     read -r -p "$(Info "Do you want to uninstall Wineprefix? (y/N)")" wineprch
 
     if [ "$wineprch" = 'y' ] || [ "$wineprch" = 'Y' ]; then
-        rm -rf "$HOME/.local/share/wineprefixes/osu-wineprefix"
+        rm -rf "$XDG_DATA_HOME/wineprefixes/osu-wineprefix"
     else
         Info "Skipping.." ; fi
 
@@ -683,21 +685,21 @@ function Uninstall(){
         if [ "$choice2" = 'y' ] || [ "$choice2" = 'Y' ]; then
 		    
             Info "Uninstalling game:"
-            if [ -e "$HOME/.local/share/osuconfig/osupath" ]; then
-                OSUUNINSTALLPATH=$(<"$HOME/.local/share/osuconfig/osupath")
+            if [ -e "$XDG_DATA_HOME/osuconfig/osupath" ]; then
+                OSUUNINSTALLPATH=$(<"$XDG_DATA_HOME/osuconfig/osupath")
 		        rm -rf "$OSUUNINSTALLPATH"
-                rm -rf "$HOME/.local/share/osuconfig"
+                rm -rf "$XDG_DATA_HOME/osuconfig"
             else
-                rm -rf "$HOME/.local/share/osuconfig"
+                rm -rf "$XDG_DATA_HOME/osuconfig"
             fi
 
         else
-            rm -rf "$HOME/.local/share/osuconfig"
+            rm -rf "$XDG_DATA_HOME/osuconfig"
             Info "Exiting.."
         fi
     
     else
-        rm -rf "$HOME/.local/share/osuconfig"
+        rm -rf "$XDG_DATA_HOME/osuconfig"
     fi
     
     Info "Uninstallation completed!"
@@ -708,11 +710,11 @@ function Uninstall(){
 function Gosumemory(){
     GOSUMEMORY_LINK="https://github.com/l3lackShark/gosumemory/releases/download/1.3.9/gosumemory_windows_amd64.zip"
 
-    if [ ! -d "$HOME/.local/share/osuconfig/gosumemory" ]; then
+    if [ ! -d "$XDG_DATA_HOME/osuconfig/gosumemory" ]; then
         Info "Installing gosumemory.."
-        mkdir -p "$HOME/.local/share/osuconfig/gosumemory"
+        mkdir -p "$XDG_DATA_HOME/osuconfig/gosumemory"
         wget -O "/tmp/gosumemory.zip" "$GOSUMEMORY_LINK" || Error "Download failed, check your connection.."
-        unzip -d "$HOME/.local/share/osuconfig/gosumemory" -q "/tmp/gosumemory.zip"
+        unzip -d "$XDG_DATA_HOME/osuconfig/gosumemory" -q "/tmp/gosumemory.zip"
         rm "/tmp/gosumemory.zip"
     fi
 }
@@ -720,18 +722,18 @@ function Gosumemory(){
 function tosu(){
     TOSU_LINK="https://github.com/tosuapp/tosu/releases/download/v4.3.1/tosu-windows-v4.3.1.zip"
     
-    if [ ! -d "$HOME/.local/share/osuconfig/tosu" ]; then
+    if [ ! -d "$XDG_DATA_HOME/osuconfig/tosu" ]; then
         Info "Installing tosu.."
-        mkdir -p "$HOME/.local/share/osuconfig/tosu"
+        mkdir -p "$XDG_DATA_HOME/osuconfig/tosu"
         wget -O "/tmp/tosu.zip" "$TOSU_LINK" || Error "Download failed, check your connection.."
-        unzip -d "$HOME/.local/share/osuconfig/tosu" -q "/tmp/tosu.zip"
+        unzip -d "$XDG_DATA_HOME/osuconfig/tosu" -q "/tmp/tosu.zip"
         rm "/tmp/tosu.zip"
     fi
 }
 
 function FixUmu(){
-    UMU_RUN="${UMU_RUN:-"$HOME/.local/share/osuconfig/proton-osu/umu-run"}"
-    if [ ! -f "$HOME/.local/bin/osu-wine" ]; then
+    UMU_RUN="${UMU_RUN:-"$XDG_DATA_HOME/osuconfig/proton-osu/umu-run"}"
+    if [ ! -f "$BINDIR/osu-wine" ]; then
         Info "Looks like you haven't installed osu-winello yet, so you should run ./osu-winello.sh first."
         return
     elif [ ! -f "${UMU_RUN}" ]; then
@@ -740,7 +742,7 @@ function FixUmu(){
     fi
 
     Info "Removing umu-launcher..."
-    rm -rf "${HOME}/.local/share/umu" "${HOME}/.local/share/pybstrap"
+    rm -rf "$XDG_DATA_HOME/umu" "$XDG_DATA_HOME/pybstrap"
 
     Info "Reinstalling umu-launcher..."
     UMU_NO_PROTON=1 GAMEID="umu-727" "$UMU_RUN" true && chk="$?"

--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -742,7 +742,12 @@ function FixUmu(){
     fi
 
     Info "Removing umu-launcher..."
-    rm -rf "$XDG_DATA_HOME/umu" "$XDG_DATA_HOME/pybstrap"
+    # As of writing, umu-launcher still hardcodes $HOME/.local/share
+    # rather than respecting $XDG_DATA_HOME. To be safe, try cleaning
+    # under both directories.
+    for base in "$XDG_DATA_HOME" "$HOME/.local/share"; do
+        rm -rf "$base/umu" "$base/pybstrap"
+    done
 
     Info "Reinstalling umu-launcher..."
     UMU_NO_PROTON=1 GAMEID="umu-727" "$UMU_RUN" true && chk="$?"


### PR DESCRIPTION
I like keeping my XDG_DATA_HOME user ~/var/xdg, and binaries under ~/bin, but the scripts just assume those are ~/.local/share and ~/.local/bin, respectively.
