### PR TITLE
bump wine to 10.5-1

### DIFF
--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -10,7 +10,7 @@
 # Wine-osu current versions for update
 MAJOR=10
 MINOR=4
-PATCH=1
+PATCH=3
 WINEVERSION=$MAJOR.$MINOR-$PATCH
 LASTWINEVERSION=0
 

--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -9,8 +9,8 @@
 
 # Wine-osu current versions for update
 MAJOR=10
-MINOR=4
-PATCH=3
+MINOR=5
+PATCH=1
 WINEVERSION=$MAJOR.$MINOR-$PATCH
 LASTWINEVERSION=0
 


### PR DESCRIPTION
notes at the WineBuilder repo: https://github.com/NelloKudo/WineBuilder/releases/tag/wine-osu-staging-10.5-1

Changed to build in the Proton SDK docker image, like proton-osu was, among other changes.