### PR TITLE
Fix false negative for network connection

### DIFF
--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -202,7 +202,7 @@ InitialSetup() {
 
     # Well, we do need internet ig...
     Info "Checking for internet connection.."
-    ! ping -c 1 1.1.1.1 >/dev/null 2>&1 && ! ping -c 1 google.com >/dev/null 2>&1 && InstallError "Please connect to internet before continuing xd. Run the script again"
+    ! ping -c 2 1.1.1.1 >/dev/null 2>&1 && ! ping -c 2 google.com >/dev/null 2>&1 && InstallError "Please connect to internet before continuing xd. Run the script again"
 
     # Looking for dependencies..
     deps=(pgrep realpath wget zenity unzip)
@@ -459,7 +459,7 @@ reconfigurePrefix() {
 
     [ -n "${freshprefix}" ] && {
         Info "Checking for internet connection.." # The bundled prefix install already checks for internet, so no point checking again
-        ! ping -c 1 1.1.1.1 >/dev/null 2>&1 && { Error "Please connect to internet before continuing xd. Run the script again" && return 1; }
+        ! ping -c 2 1.1.1.1 >/dev/null 2>&1 && { Error "Please connect to internet before continuing xd. Run the script again" && return 1; }
 
         [ -d "${WINEPREFIX:?}" ] && rm -rf "${WINEPREFIX}"
 


### PR DESCRIPTION
One ping always results in negative (at least on Arch)
```
ping -c 1 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.

--- 1.1.1.1 ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms
```

but succeeds for 2 or more:
```
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=1 ttl=55 time=14.0 ms
64 bytes from 1.1.1.1: icmp_seq=2 ttl=55 time=13.0 ms

--- 1.1.1.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1000ms
rtt min/avg/max/mdev = 13.009/13.520/14.031/0.511 ms
```