### PR TITLE
Add (stable) suffix to osu-wine shortcut

### DIFF
--- a/osu-winello.sh
+++ b/osu-winello.sh
@@ -283,8 +283,8 @@ InstallWine() {
     Info "Installing .desktop:"
     mkdir -p "$XDG_DATA_HOME/applications"
     echo "[Desktop Entry]
-Name=osu!
-Comment=osu! - Rhythm is just a *click* away!
+Name=osu!(stable)
+Comment=osu!(stable) - Rhythm is just a *click* away!
 Type=Application
 Exec=$BINDIR/osu-wine %U
 Icon=$XDG_DATA_HOME/icons/osu-wine.png


### PR DESCRIPTION
osu!(lazer) on linux is simply titled "osu!" on it's desktop shortcut. This makes it confusing for people with both native osu!(lazer) and osu-winello based osu!(stable). That's why I made this quick PR to change osu-winello's desktop shortcut to have a suffix "(stable)" text.